### PR TITLE
Workaround for FMS 2020.04.01 for Cheyenne with GNU 9.1.0, incl. regression test log

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "FMS"]
   path = FMS
   url = https://github.com/NOAA-GFDL/FMS
-  branch = 2020.04.01
+  branch = release/2020.04
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,17 @@ if(CMAKE_Platform)
   else()
     message("Platform '${CMAKE_Platform}' configuration file does not exist")
   endif()
+
+  # DH* 20210208 temporary workaround for FMS issues on Cheyenne with GNU 9.1.0
+  if (CMAKE_Platform MATCHES "cheyenne.gnu")
+    message("Applying patch cheyenne_gnu_fms_mpp_util_mpi_inc.patch")
+    execute_process(COMMAND patch -N -p0 INPUT_FILE cheyenne_gnu_fms_mpp_util_mpi_inc.patch
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/cheyenne_gnu_fms_mpp_util_mpi_inc.patch.out
+                    ERROR_FILE  ${CMAKE_CURRENT_BINARY_DIR}/cheyenne_gnu_fms_mpp_util_mpi_inc.patch.err
+                    RESULT_VARIABLE RC)
+    # *DH 20210208
+  endif()
 endif()
 
 message("")

--- a/cheyenne_gnu_fms_mpp_util_mpi_inc.patch
+++ b/cheyenne_gnu_fms_mpp_util_mpi_inc.patch
@@ -1,0 +1,12 @@
+--- FMS/mpp/include/mpp_util_mpi.inc	2021-02-08 08:24:21.000000000 -0700
++++ FMS/mpp/include/mpp_util_mpi.inc	2021-02-08 08:24:15.000000000 -0700
+@@ -169,7 +169,8 @@
+   integer, intent(in   ), optional :: msg_size(:)
+   integer, intent(in   ), optional :: msg_type(:)
+ 
+-  integer                       :: i, m, n, stride, my_check, rsize
++  integer                       :: i, m, n, stride, my_check
++  integer, volatile             :: rsize
+ 
+   if( debug .and. (current_clock.NE.0) )call SYSTEM_CLOCK(start_tick)
+   my_check = EVENT_SEND

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,16 +1,16 @@
-Wed Feb  3 07:58:47 MST 2021
+Mon Feb  8 10:59:13 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.nemsio .........OK
  Comparing phyf024.nemsio .........OK
  Comparing dynf000.nemsio .........OK
@@ -51,14 +51,14 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -119,14 +119,14 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_prod
 Checking test 003 fv3_ccpp_gfs_v16 results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,14 +249,14 @@ Test 004 fv3_ccpp_gfs_v16_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_stochy_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16_stochy results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -317,14 +317,14 @@ Test 005 fv3_ccpp_gfs_v16_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_flake_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16_flake results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -385,14 +385,14 @@ Test 006 fv3_ccpp_gfs_v16_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -453,14 +453,14 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_RRTMGP_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16_RRTMGP results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -521,14 +521,14 @@ Test 008 fv3_ccpp_gfs_v16_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -579,24 +579,24 @@ Checking test 009 fv3_ccpp_gsd results ....
  Comparing dynf048.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......OK
  Comparing RESTART/phy_data.tile1.nc .........OK
  Comparing RESTART/phy_data.tile2.nc .........OK
  Comparing RESTART/phy_data.tile3.nc .........OK
@@ -613,14 +613,14 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -647,24 +647,24 @@ Checking test 010 fv3_ccpp_thompson results ....
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......OK
  Comparing RESTART/phy_data.tile1.nc .........OK
  Comparing RESTART/phy_data.tile2.nc .........OK
  Comparing RESTART/phy_data.tile3.nc .........OK
@@ -681,14 +681,14 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -715,24 +715,24 @@ Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......OK
  Comparing RESTART/phy_data.tile1.nc .........OK
  Comparing RESTART/phy_data.tile2.nc .........OK
  Comparing RESTART/phy_data.tile3.nc .........OK
@@ -749,14 +749,14 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -783,24 +783,24 @@ Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing dynf024.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......OK
  Comparing RESTART/phy_data.tile1.nc .........OK
  Comparing RESTART/phy_data.tile2.nc .........OK
  Comparing RESTART/phy_data.tile3.nc .........OK
@@ -817,14 +817,14 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -885,9 +885,9 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
- Comparing atmos_4xdaily.nc .........OK
+ Comparing atmos_4xdaily.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf012.nc .........OK
  Comparing dynf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_control_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_control_debug_prod
 Checking test 015 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -933,14 +933,14 @@ Test 015 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1001,14 +1001,14 @@ Test 016 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_debug_prod
 Checking test 017 fv3_ccpp_gfs_v16_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1069,14 +1069,14 @@ Test 017 fv3_ccpp_gfs_v16_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1137,14 +1137,14 @@ Test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_gfs_v16_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_gfs_v16_RRTMGP_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16_RRTMGP_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1205,14 +1205,14 @@ Test 019 fv3_ccpp_gfs_v16_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1239,24 +1239,24 @@ Checking test 020 fv3_ccpp_multigases results ....
  Comparing dynf006.tile6.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc ............SKIP for gnu compilers
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......OK
  Comparing RESTART/phy_data.tile1.nc .........OK
  Comparing RESTART/phy_data.tile2.nc .........OK
  Comparing RESTART/phy_data.tile3.nc .........OK
@@ -1279,14 +1279,14 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
+ Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile3.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile4.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile5.nc ............ALT CHECK......OK
+ Comparing atmos_4xdaily.tile6.nc ............ALT CHECK......OK
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
  Comparing phyf000.tile3.nc .........OK
@@ -1347,9 +1347,9 @@ Test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210128/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/worthen/FV3_RT/rt_19651/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_22326/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
- Comparing atmos_4xdaily.nc .........OK
+ Comparing atmos_4xdaily.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1365,5 +1365,5 @@ Test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Feb  3 08:16:48 MST 2021
-Elapsed time: 00h:18m:01s. Have a nice day!
+Mon Feb  8 11:16:42 MST 2021
+Elapsed time: 00h:17m:29s. Have a nice day!


### PR DESCRIPTION
As discussed by email ... in case you want to use this workaround, please merge it into your code. Thanks!